### PR TITLE
Refactor parsing of api data annotations

### DIFF
--- a/src/assets/defaultTemplate.njk
+++ b/src/assets/defaultTemplate.njk
@@ -6,6 +6,13 @@
 {% if url %}- Reference: {{url}}{% endif %}
 - Category: #article{% endif %}
 
+{% if is_new_article%}## Page Notes
+{% for highlight in page_notes -%}
+{{highlight.annotation}}
+{% if highlight.tags | length %} Tags: {% for tag in highlight.tags -%} #{{tag | replace(" ", "-")+" "}}{%- endfor %}{%- endif %}
+{%- endfor -%}
+{% endif %}
+
 {% if is_new_article -%}## Highlights{%- endif %}
 {% for highlight in highlights -%}- {{highlight.text}} — [Updated on {{highlight.updated}}]({{highlight.incontext}}) {% if 'Private' != highlight.group %} — Group: #{{highlight.group| replace(" ", "-")}}{%- endif %}
 {% if highlight.tags | length %}   - Tags: {% for tag in highlight.tags -%} #{{tag | replace(" ", "-")+" "}}{%- endfor %}{%- endif %}

--- a/src/models.ts
+++ b/src/models.ts
@@ -2,6 +2,7 @@ export type Article = {
   id: string;
   metadata: Metadata;
   highlights: Highlights[];
+  page_notes: Highlights[];
 };
 
 export type Metadata = {
@@ -21,6 +22,7 @@ export type Highlights = {
   annotation: string;
   tags: string[];
   group: string;
+  isReply: boolean;
 };
 
 export type RenderTemplate = {
@@ -28,16 +30,8 @@ export type RenderTemplate = {
   title: string;
   author: string;
   url: string;
-  highlights: {
-    text: string;
-    incontext?: string;
-    created?: string;
-    updated?: string;
-    user?: string;
-    annotation: string;
-    tags: string[];
-    group: string;
-  }[];
+  highlights: Highlights[];
+  page_notes: Highlights[];
 };
 
 export type Group = {

--- a/src/parser/parseSyncResponse.ts
+++ b/src/parser/parseSyncResponse.ts
@@ -38,9 +38,7 @@ const parseHighlight = (annotationData, momentFormat: string): Highlights => {
                 isReply = true
             }
          }
-
-        const excludedTags = ["via-lindylearn.io", "via annotations.lindylearn.io", "lindylearn"];
-    
+  
         return {
             id: annotationData['id'],
             created: moment(annotationData['created']).format(momentFormat),
@@ -49,7 +47,7 @@ const parseHighlight = (annotationData, momentFormat: string): Highlights => {
             incontext: annotationData['links']['incontext'],
             user: annotationData['user'],
             annotation: annotationData['text'],
-            tags: annotationData['tags'].filter(tag => !excludedTags.includes(tag)),
+            tags: annotationData['tags'],
             group: annotationData.name,
             isReply,
         }

--- a/src/parser/parseSyncResponse.ts
+++ b/src/parser/parseSyncResponse.ts
@@ -2,6 +2,7 @@ import md5 from 'crypto-js/md5';
 import { moment } from 'obsidian';
 import { settingsStore } from '~/store';
 import { get } from 'svelte/store';
+import type { Article, Highlights } from '../models'
 
 const parseAuthorUrl = (url: string) => {
     const domain = (new URL(url));
@@ -9,65 +10,95 @@ const parseAuthorUrl = (url: string) => {
     return author;
 }
 
+const parseTitleFromUrl = (url: string) => {
+    const domain = (new URL(url));
+    let pathname = domain.pathname
 
-const parseSyncResponse = async (data) => {
+    // Remove leading and optional trailing slash
+    pathname = pathname.slice(1)
+    if (pathname.endsWith("/")) {
+        pathname = pathname.slice(0, pathname.length - 1)
+    }
+        
+    return pathname.replaceAll('/', '-');
+}
+
+const parseHighlight = (annotationData, momentFormat: string): Highlights => {
+    try {   
+        // Get highlighted text or reply
+        let isReply, highlightText = null;
+        const selector = annotationData['target'][0]['selector']
+        if (selector) {
+            highlightText = selector
+                .find(item => item.type === "TextQuoteSelector")
+                ?.exact
+        } else {
+            // Could be page note or reply
+            if (annotationData['references']) {
+                isReply = true
+            }
+         }
+
+        const excludedTags = ["via-lindylearn.io", "via annotations.lindylearn.io", "lindylearn"];
+    
+        return {
+            id: annotationData['id'],
+            created: moment(annotationData['created']).format(momentFormat),
+            updated: moment(annotationData['updated']).format(momentFormat),
+            text: highlightText,
+            incontext: annotationData['links']['incontext'],
+            user: annotationData['user'],
+            annotation: annotationData['text'],
+            tags: annotationData['tags'].filter(tag => !excludedTags.includes(tag)),
+            group: annotationData.name,
+            isReply,
+        }
+    } catch (error) {
+
+        console.log(`Error parsing annotation format: ${error}`, annotationData);
+        return null
+    }
+}
+
+
+const parseSyncResponse = (data): Article[] => {
     const momentFormat = get(settingsStore).dateTimeFormat;
     const groups = get(settingsStore).groups;
 
-    return data.reduce((result, current) => {
+    // Group annotations per article
+    const articlesMap = data.reduce((result, annotationData) => {
+        const url = annotationData['uri'];
+        const md5Hash = md5(url);
 
-        //skip pdf source
-        if ((current['uri']).startsWith('urn:x-pdf')) {
+        // Skip pdf source
+        if ((url).startsWith('urn:x-pdf')) {
             return result;
         }
 
-        //Check if group is selected
-        const group = groups.find(k => k.id == current['group']);
+        // Check if group is selected
+        const group = groups.find(k => k.id == annotationData['group']);
         if (!group.selected) {
             return result;
         }
-
-        const md5Hash = md5(current['uri']);
-        let selectorText = 'No highlighted text';
-
-        try {
-
-            // Get document metadata; title
-            if (!result[md5Hash]) {
-                result[md5Hash] = { id: md5Hash, metadata: { title: current['document']['title'][0], url: current['uri'], author: parseAuthorUrl(current['uri']) }, highlights: [] };
-            }
-
-            // Get highlighted text
-            const val = "TextQuoteSelector";
-            const selector = current['target'][0]['selector']
-            selector.find(function (item, i) {
-                if (item.type === val) {
-                    selectorText = item.exact;
-                    return i;
-                }
-            });
-
-            result[md5Hash].highlights.push(
-                {
-                    id: current['id'],
-                    created: moment(current['created']).format(momentFormat),
-                    updated: moment(current['updated']).format(momentFormat),
-                    text: selectorText,
-                    incontext: current['links']['incontext'],
-                    user: current['user'],
-                    annotation: current['text'],
-                    tags: current['tags'],
-                    group: group.name,
-                }
-            );
-
-        } catch (error) {
-            console.log(`Possible missing highlights or document title. ${error}`, current);
+       
+        const title = annotationData['document']['title']?.[0] || parseTitleFromUrl(url);
+        const author = parseAuthorUrl(url);
+        // Set article metadata, if not already set by previous annotation
+        if (!result[md5Hash]) {
+            result[md5Hash] = { id: md5Hash, metadata: { title, url, author }, highlights: [], page_notes: [] };
         }
 
+        const annotation = parseHighlight(annotationData, momentFormat)
+        if (!annotation.text && !annotation.isReply) {
+            result[md5Hash].page_notes.push(annotation);
+        } else {
+            result[md5Hash].highlights.push(annotation);
+        }
+        
         return result;
     }, {});
 
+    return Object.values(articlesMap)
 }
 
 export default parseSyncResponse;

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -18,14 +18,13 @@ export class Renderer {
   }
 
   render(entry: Article, isNew = true): string {
-    const { metadata , highlights } = entry;
+    const { metadata , highlights, page_notes } = entry;
 
     const context: RenderTemplate = {
        is_new_article: isNew,
        ...metadata,
-       highlights: highlights.map((a) => ({
-        ...a
-       }))
+       highlights,
+       page_notes,
     };
 
     const template = get(settingsStore).template;

--- a/src/store/syncSession.ts
+++ b/src/store/syncSession.ts
@@ -72,7 +72,7 @@ const createSyncSessionStore = () => {
 
   const setJobs = (articles: Article[]) => {
     store.update((state) => {
-      for (const article of Object.values(articles)) {
+      for (const article of articles) {
         state.jobs.push({ status: 'idle', articleId: article.id });
       }
       return state;

--- a/src/sync/syncHypothesis.ts
+++ b/src/sync/syncHypothesis.ts
@@ -33,12 +33,12 @@ export default class SyncHypothesis {
 
         //fetch highlights
         const responseBody: [] = (!uri) ? await apiManager.getHighlights(get(settingsStore).lastSyncDate) : await apiManager.getHighlightWithUri(uri);
-        const syncedArticles: [] = await parseSyncResponse(responseBody);
+        const articles = await parseSyncResponse(responseBody);
 
-        syncSessionStore.actions.setJobs(syncedArticles);
+        syncSessionStore.actions.setJobs(articles);
 
-        if (Object.keys(syncedArticles).length > 0) {
-            await this.syncArticles(syncedArticles);
+        if (articles.length > 0) {
+            await this.syncArticles(articles);
         }
 
         syncSessionStore.actions.completeSync({
@@ -51,7 +51,7 @@ export default class SyncHypothesis {
 
     private async syncArticles(articles: Article[]): Promise<void> {
 
-        for (const article of Object.values(articles)) {
+        for (const article of articles) {
             try {
                 syncSessionStore.actions.startJob(article);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,10 @@
     "paths": {
       "src": ["src/*", "tests/*"],
       "~/*": ["src/*"]
-    }
+    },
+    "lib": [
+      "es2021"
+    ]
   },
   "esModuleInterop": true
 }


### PR DESCRIPTION
Thank you for creating this awesome plugin!

This PR refactors the parsing of annotations data in `src/parser/parseSyncResponse.ts` a bit. This allows to:
* Detect and render Page Notes
* Use a fallback title inferred from the URL path if the metadata title is not set

Sorry for the large LOC count :/ See the inline comments for context.