### PR TITLE
Support grouping files by URL domain

### DIFF
--- a/src/settingsTab/index.ts
+++ b/src/settingsTab/index.ts
@@ -42,6 +42,7 @@ export class SettingsTab extends PluginSettingTab {
     }
     this.autoSyncInterval();
     this.highlightsFolder();
+    this.folderPath();
     this.syncOnBoot();
     this.dateFormat();
     this.template();
@@ -176,6 +177,19 @@ export class SettingsTab extends PluginSettingTab {
           });
         return text;
       });
+  }
+
+  private folderPath(): void {
+    new Setting(this.containerEl)
+    .setName('Use domain folders')
+    .setDesc('Group generated files into folders based on the domain of the annotated URL')
+    .addToggle((toggle) =>
+      toggle
+        .setValue(get(settingsStore).useDomainFolders)
+        .onChange(async (value) => {
+          await settingsStore.actions.setUseDomainFolder(value);
+        })
+    );
   }
 
   private syncOnBoot(): void {

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -21,6 +21,7 @@ type Settings = {
   autoSyncInterval: number;
   syncedFiles: SyncedFile[];
   groups: Group[];
+  useDomainFolders: boolean;
 };
 
 const DEFAULT_SETTINGS: Settings = {
@@ -37,7 +38,8 @@ const DEFAULT_SETTINGS: Settings = {
     totalHighlights: 0,
   },
   syncedFiles: [],
-  groups: []
+  groups: [],
+  useDomainFolders: false,
 };
 
 const createSettingsStore = () => {
@@ -181,6 +183,13 @@ const createSettingsStore = () => {
     });
   };
 
+  const setUseDomainFolder = (value: boolean) => {
+    store.update((state) => {
+      state.useDomainFolders = value;
+      return state;
+    });
+  };
+
   return {
     subscribe: store.subscribe,
     initialise,
@@ -197,7 +206,8 @@ const createSettingsStore = () => {
       setDateTimeFormat,
       addSyncedFile,
       setGroups,
-      resetGroups
+      resetGroups,
+      setUseDomainFolder,
     },
   };
 };


### PR DESCRIPTION
Add the ability to group generated files into folders based on the URL domain of the annotated article, if enabled via the plugin settings.

I find that some file structure helps it to feel manageable with 200+ annotated articles. Even if most folders only contain one article file. It's disabled by default because it'll not work with existing synced files.

I'm not sure how many additional uses cases there are to justify adding a fully customizable path based on a template.