### PR TITLE
Strip whitespace from highlight text

### DIFF
--- a/src/parser/parseSyncResponse.ts
+++ b/src/parser/parseSyncResponse.ts
@@ -9,6 +9,20 @@ const parseAuthorUrl = (url: string) => {
     return author;
 }
 
+// Strip excessive whitespace and newlines from the TextQuoteSelector highlight text
+// This mirrors how Hypothesis displays annotations, to remove artifacts from the HTML annotation anchoring
+export const cleanTextSelectorHighlight = (text: string): string => {
+    text = text.replaceAll('\n', ' ') // e.g. http://www.paulgraham.com/venturecapital.html
+    text = text.replace('\t', ' ') // e.g. https://sive.rs/about
+
+    // Remove space-indented lines, e.g. https://calpaterson.com/bank-python.html
+    while (text.contains('  ')) {
+        text = text.replaceAll('  ', ' ')
+    }
+
+    return text
+};
+
 
 const parseSyncResponse = async (data) => {
     const momentFormat = get(settingsStore).dateTimeFormat;
@@ -52,7 +66,7 @@ const parseSyncResponse = async (data) => {
                     id: current['id'],
                     created: moment(current['created']).format(momentFormat),
                     updated: moment(current['updated']).format(momentFormat),
-                    text: selectorText,
+                    text: selectorText && cleanTextSelectorHighlight(selectorText),
                     incontext: current['links']['incontext'],
                     user: current['user'],
                     annotation: current['text'],


### PR DESCRIPTION
Hypothesis annotation `TextQuoteSelector`s may include newlines, tabs, or space-indented tabs as artifacts of anchoring annotations inside the HTML document. To mirror the display of quotes inside Hypothesis, this PR strips this whitespace from the rendered quotes.

This should make highlights look nice in *more* cases, I don't think perfect is possible here. The user can always modify the highlight in the rendered file to make it more comprehensible.

Before example:

<img width="689" alt="Screenshot 2022-02-23 at 11 02 46 AM" src="https://user-images.githubusercontent.com/23430759/155298149-b57aba2d-afaf-4470-a8e7-ca1aa18fb8d5.png">

After example:

<img width="691" alt="Screenshot 2022-02-23 at 11 01 58 AM" src="https://user-images.githubusercontent.com/23430759/155298170-dfe6efd3-1c6c-4cdc-8408-a26df2d7d870.png">
