### PR TITLE
Refactor API methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
   "author": "weichenw",
   "license": "MIT",
   "dependencies": {
-    "nunjucks": "^3.2.3",
-    "lodash.pickby": "^4.6.0"
+    "axios": "^0.26.0",
+    "lodash.pickby": "^4.6.0",
+    "nunjucks": "^3.2.3"
   },
   "devDependencies": {
     "@babel/core": "^7.15.8",

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -22,7 +22,7 @@ export default class ApiManager {
   async getProfile() {
     try {
       const response = await axios.get(`${this.baseUrl}/profile`, { headers: this.getHeaders() })
-      return response.data.userId
+      return response.data.userid
     }
     catch (e) {
       new Notice('Failed to authorize Hypothes.is user. Please check your API token and try again.')


### PR DESCRIPTION
Refactor the Hypothesis API communication code, to remove boilerplate and make changes easier. This is helpful for me to implement additional methods for bi-directional annotations syncing in my fork.

With this, annotations are always iterated through `search_after` (not `limit`), which fixes the edge case of missing annotations in later syncs. I wrangled the Hypothesis API for another project before, and this seems to be the best way to work around the pagination issues.