### PR TITLE
Match generated files by frontmatter

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
   "author": "weichenw",
   "license": "MIT",
   "dependencies": {
-    "nunjucks": "^3.2.3",
-    "lodash.pickby": "^4.6.0"
+    "gray-matter": "^4.0.3",
+    "lodash.pickby": "^4.6.0",
+    "nunjucks": "^3.2.3"
   },
   "devDependencies": {
     "@babel/core": "^7.15.8",

--- a/src/fileManager.ts
+++ b/src/fileManager.ts
@@ -36,7 +36,7 @@ export default class FileManager {
       await this.vault.modify(existingFile, fileContent);
       return false;
     } else {
-      const newFilePath = await this.getNewArticleFilePath(article);
+      const newFilePath = this.getNewArticleFilePath(article);
       console.debug(`Creating ${newFilePath}`);
 
       const markdownContent = this.renderer.render(article, true);
@@ -45,6 +45,11 @@ export default class FileManager {
       await this.vault.create(newFilePath, fileContent);
       return true;
     }
+  }
+
+  public async isArticleSaved(article: Article): Promise<boolean> {
+    const file = await this.getArticleFile(article);
+    return !!file
   }
 
   private async getArticleFile(article: Article): Promise<TFile | null> {
@@ -65,13 +70,9 @@ export default class FileManager {
       .map(({ file, frontmatter }): AnnotationFile => ({file, articleUrl: frontmatter["url"]}))
   }
 
-  private async getNewArticleFilePath(article: Article): Promise<string> {
+  public getNewArticleFilePath(article: Article): string {
     const settings = get(settingsStore);
     let folderPath = settings.highlightsFolder;
-
-    if (!(await this.vault.adapter.exists(folderPath))) {
-      await this.vault.createFolder(folderPath);
-    }
 
     const fileName = `${sanitizeTitle(article.metadata.title)}.md`;
     const filePath = `${folderPath}/${fileName}`  

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ export default class HypothesisPlugin extends Plugin {
 
 		await initialise(this);
 
-		const fileManager = new FileManager(this.app.vault);
+		const fileManager = new FileManager(this.app.vault, this.app.metadataCache);
 
 		this.syncHypothesis = new SyncHypothesis(fileManager);
 

--- a/src/modals/resyncDelFileModal.ts
+++ b/src/modals/resyncDelFileModal.ts
@@ -27,7 +27,7 @@ export default class ResyncDelFileModal extends Modal {
 
     async onOpen() {
         super.onOpen()
-        const fileManager = new FileManager(this.vault);
+        const fileManager = new FileManager(this.vault, this.app.metadataCache);
 		this.syncHypothesis = new SyncHypothesis(fileManager);
         const deletedFiles = await this.retrieveDeletedFiles(this.vault);
 

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -19,7 +19,6 @@ type Settings = {
   history: SyncHistory;
   dateTimeFormat: string;
   autoSyncInterval: number;
-  syncedFiles: SyncedFile[];
   groups: Group[];
 };
 
@@ -36,7 +35,6 @@ const DEFAULT_SETTINGS: Settings = {
     totalArticles: 0,
     totalHighlights: 0,
   },
-  syncedFiles: [],
   groups: []
 };
 
@@ -105,7 +103,6 @@ const createSettingsStore = () => {
       state.history.totalArticles = 0;
       state.history.totalHighlights = 0;
       state.lastSyncDate = undefined;
-      state.syncedFiles = [];
       return state;
     });
   };
@@ -153,20 +150,6 @@ const createSettingsStore = () => {
     });
   };
 
-  const addSyncedFile = (value: SyncedFile) => {
-    store.update((state) => {
-      const uniqueValuesSet = new Set();
-      const syncFiles = [...state.syncedFiles, value];
-      state.syncedFiles = syncFiles.filter((obj) => {
-        const isPresentInSet = uniqueValuesSet.has(obj.filename);
-        uniqueValuesSet.add(obj.filename);
-        return !isPresentInSet;
-      });
-
-      return state;
-    });
-  }
-
   const setGroups = async (value: Group[]) => {
     store.update((state) => {
       state.groups = value;
@@ -195,7 +178,6 @@ const createSettingsStore = () => {
       setSyncOnBoot,
       incrementHistory,
       setDateTimeFormat,
-      addSyncedFile,
       setGroups,
       resetGroups
     },

--- a/src/sync/syncHypothesis.ts
+++ b/src/sync/syncHypothesis.ts
@@ -68,7 +68,7 @@ export default class SyncHypothesis {
 
     private async syncArticle(article: Article): Promise<void> {
 
-        const createdNewArticle = await this.fileManager.createOrUpdate(article);
+        const createdNewArticle = await this.fileManager.saveArticle(article);
 
         if (createdNewArticle) {
             this.syncState.newArticlesSynced += 1;

--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -1,0 +1,17 @@
+import matter from "gray-matter"
+import type { Article } from '~/models';
+
+type FrontMatterContent = {
+    doc_type?: string;
+    url?: string;
+}
+
+export const frontMatterDocType = "hypothesis-highlights"
+
+export const addFrontMatter = (markdownContent: string, article: Article) => {
+    const frontMatter: FrontMatterContent = {
+        doc_type: frontMatterDocType,
+        url: article.metadata.url,
+    };
+    return matter.stringify(markdownContent, frontMatter);
+}


### PR DESCRIPTION
When writing new highlights to markdown files, check if an existing file with the article URL in its frontmatter already exists. Create this frontmatter for new files. Releasing this will require people to reset & delete all their existing files, so we may want to add a migration path in another PR.

New files created after this change merges can be moved around or renamed freely.

The markdown files now somewhat act as the `synchedFiles` state which was kept manually before. Thus I deleted that state and rewrote the logic of `hypothesis-resync-deleted` to match the Hypothesis API response to this local state.

@weichenw what's your feedback on this?

References:
- `obsidian-kindle-plugin` implementation of frontmatter matching https://github.com/hadynz/obsidian-kindle-plugin/blob/master/src/fileManager/index.ts
- Obsidian `MetadataCache` API docs: https://github.com/obsidianmd/obsidian-api/blob/master/obsidian.d.ts#L2033