### PR TITLE
Add suffix to file name to avoid creation failure

### DIFF
--- a/src/fileManager.ts
+++ b/src/fileManager.ts
@@ -92,8 +92,17 @@ export default class FileManager {
       await this.createFolder(folderPath);
     }
 
-    const fileName = `${sanitizeTitle(article.metadata.title)}.md`;
-    const filePath = `${folderPath}/${fileName}`
+    let fileName = `${sanitizeTitle(article.metadata.title)}.md`;
+    let filePath = `${folderPath}/${fileName}`
+
+    let suffix = 1;
+    const tfiles = this.vault.getMarkdownFiles();
+    while (tfiles.find((tfile) => tfile.path === filePath)) {
+      console.debug(`${filePath} alreay exists`)
+      fileName = `${sanitizeTitle(article.metadata.title)} (${suffix++}).md`;
+      filePath = `${folderPath}/${fileName}`;
+    }
+
     return filePath;
   }
 


### PR DESCRIPTION
Articles may have different URLs but share the same title (say, you highlight content from different pages in the same forum discussion). `getNewArticleFilePath()` now may add a suffix to the file name to avoid creation failure caused by name collision.