### PR TITLE
Fix multiple annotation template rendering

### DIFF
--- a/src/assets/defaultTemplate.njk
+++ b/src/assets/defaultTemplate.njk
@@ -1,19 +1,30 @@
-{% if is_new_article %}# {{title}}
+{% if is_new_article %}
+# {{title}}
 
 ## Metadata
 {% if author %}- Author: [{{author}}]({{authorUrl}}){% endif %}
 - Title: {{title}}
 {% if url %}- Reference: {{url}}{% endif %}
-- Category: #article{% endif %}
-
-{% if is_new_article%}## Page Notes
-{% for highlight in page_notes -%}
-{{highlight.annotation}}
-{% if highlight.tags | length %} Tags: {% for tag in highlight.tags -%} #{{tag | replace(" ", "-")+" "}}{%- endfor %}{%- endif %}
-{%- endfor -%}
+- Category: #article
 {% endif %}
 
-{% if is_new_article -%}## Highlights{%- endif %}
-{% for highlight in highlights -%}- {{highlight.text}} — [Updated on {{highlight.updated}}]({{highlight.incontext}}) {% if 'Private' != highlight.group %} — Group: #{{highlight.group| replace(" ", "-")}}{%- endif %}
-{% if highlight.tags | length %}   - Tags: {% for tag in highlight.tags -%} #{{tag | replace(" ", "-")+" "}}{%- endfor %}{%- endif %}
-{% if highlight.annotation %}   - Annotation: {{highlight.annotation}}{%- endif -%}{%- endfor -%}
+{%- if is_new_article %}
+## Page Notes
+{% for highlight in page_notes -%}
+{{highlight.annotation}}
+{%- if highlight.tags | length %}
+Tags: {% for tag in highlight.tags -%} #{{tag | replace(" ", "-")+" "}}{%- endfor %}
+{% endif %}
+{% endfor %}
+{%- endif -%}
+
+{%- if is_new_article -%}
+## Highlights
+{% for highlight in highlights -%}
+- {{highlight.text}} — [Updated on {{highlight.updated}}]({{highlight.incontext}})
+{%- if 'Private' != highlight.group %} — Group: #{{highlight.group | replace(" ", "-")}}{% endif %}
+{% if highlight.tags | length %}    - Tags: {% for tag in highlight.tags %} #{{tag | replace(" ", "-")+" "}}{% endfor %}
+{% endif -%}
+{% if highlight.annotation %}    - Annotation: {{highlight.annotation}}{% endif %}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
This fixes nunjucks template rendering of multiple annotations.

Default template would cause omitting original highlights that specific annotations were describing and just rolling them under the first user highlight in the text.

Signed-off-by: Radek Kozak <radoslaw.kozak@gmail.com