### PR TITLE
feat: Support folder structure based on article URL path

### DIFF
--- a/src/fileManager.ts
+++ b/src/fileManager.ts
@@ -13,12 +13,19 @@ type AnnotationFile = {
 
 const articleFolderPath = (article: Article): string => {
   const settings = get(settingsStore);
+  let folderPath = settings.highlightsFolder;
+
   if (settings.useDomainFolders) {
     // "metadata.author" is equal to the article domain at the moment
-    return `${settings.highlightsFolder}/${article.metadata.author}`;
+      folderPath = `${folderPath}/${article.metadata.author}`;
   }
 
-  return settings.highlightsFolder;
+  if (settings.useURLPathFolders) {
+      const pathname = new URL(article.metadata.url).pathname.replace(/\/$/, '');
+      folderPath = `${folderPath}/${pathname}`;
+  }
+
+  return folderPath;
 };
 
 export default class FileManager {

--- a/src/settingsTab/index.ts
+++ b/src/settingsTab/index.ts
@@ -43,6 +43,7 @@ export class SettingsTab extends PluginSettingTab {
     this.autoSyncInterval();
     this.highlightsFolder();
     this.folderPath();
+    this.folderURLPath()
     this.syncOnBoot();
     this.dateFormat();
     this.template();
@@ -188,6 +189,22 @@ export class SettingsTab extends PluginSettingTab {
         .setValue(get(settingsStore).useDomainFolders)
         .onChange(async (value) => {
           await settingsStore.actions.setUseDomainFolder(value);
+        })
+    );
+  }
+
+  private folderURLPath(): void {
+
+    new Setting(this.containerEl)
+    .setName('Use URL path folders')
+    .setDesc('The generated file directory is based on the path of the highlight URL.' +
+        'This option is designed to prevent filename conflicts caused by identical webpage titles under different paths of a website' +
+        'It is recommended to enable this option only when "Use domain folders" is enabled.')
+    .addToggle((toggle) =>
+      toggle
+        .setValue(get(settingsStore).useDomainFolders)
+        .onChange(async (value) => {
+          await settingsStore.actions.setURLPathFolders(value);
         })
     );
   }

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -21,6 +21,7 @@ type Settings = {
   autoSyncInterval: number;
   groups: Group[];
   useDomainFolders: boolean;
+  useURLPathFolders: boolean;
 };
 
 const DEFAULT_SETTINGS: Settings = {
@@ -37,7 +38,8 @@ const DEFAULT_SETTINGS: Settings = {
     totalHighlights: 0,
   },
   groups: [],
-  useDomainFolders: false
+  useDomainFolders: false,
+  useURLPathFolders: false
 };
 
 const createSettingsStore = () => {
@@ -173,6 +175,13 @@ const createSettingsStore = () => {
     });
   };
 
+  const setURLPathFolders = (value: boolean) => {
+    store.update((state) => {
+      state.useURLPathFolders = value;
+      return state;
+    });
+  };
+
   return {
     subscribe: store.subscribe,
     initialise,
@@ -190,6 +199,7 @@ const createSettingsStore = () => {
       setGroups,
       resetGroups,
       setUseDomainFolder,
+      setURLPathFolders
     },
   };
 };


### PR DESCRIPTION
When "Use domain folders" is enabled, if pages with the same title exist under different paths within the same domain, file name conflicts may occur. Although this is resolved by adding a numeric suffix to the file name, the suffix number may change with each synchronization, which can cause internal links in Obsidian to fail to find the correct file after re-synchronization.

To address this issue, an option is added to allow users to choose whether to use the URL path of the page where the annotation is located as the path for the synchronized file.